### PR TITLE
Got rid of contact line

### DIFF
--- a/Iris/splash.html
+++ b/Iris/splash.html
@@ -75,7 +75,6 @@
           <h3>Credits</h3>
           <p>
             The IRIS Web Terminal was developed by the KBase Team.<br/>
-            For questions and comments email <a href="mailto:help@kbase.us">help@kbase.us</a>
           </p>
           <p>
             IRIS is a legacy system and is no longer officially supported. IRIS will be decommissioned on May 18, 2015. Please see <a href = 'http://kbase.us/iris/'>http://kbase.us/iris/</a> for more information.


### PR DESCRIPTION
I know this is legacy code, but I don't want the old help email address out in the wild. (I found this via a Google search.)